### PR TITLE
Feature/apply keyword model on documents

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ import json
 from datetime import datetime, timedelta
 
 from backend.service import SolrService, SolrMiddleware
-from backend.solr import SolrDoc, SolrHierarchy
+from backend.solr import SolrDoc, SolrHierarchy, SolrDocKeyword, SolrDocKeywordTypes
 
 
 import logging as log
@@ -88,9 +88,11 @@ def change_keywords():
 
     try:
         solDoc = solr.docs.get(id)
-        solDoc.keywords = keywords
+        # TODO change SolrDocKeyWordType.KWM to the correct model
+        solDoc.keywords = [SolrDocKeyword(kw, SolrDocKeywordTypes.KWM) for kw in keywords]
         solr.docs.update(solDoc)
     except Exception as e:
+        print(e)
         return jsonify(f"Bad Gateway to solr: {e}"), 502
 
     print('changed keywords on file ' + id + ' to ' + ','.join(keywords) , file=sys.stdout)

--- a/backend/solr/__init__.py
+++ b/backend/solr/__init__.py
@@ -1,4 +1,4 @@
 from .docstorage import SolrDocStorage
-from .doc import SolrDoc
+from .doc import SolrDoc, SolrDocKeyword, SolrDocKeywordTypes
 from backend.solr import config
 from .keywordmodel import SolrKeywordModel, SolrHierarchy, SolrKeywords

--- a/backend/solr/docstorage.py
+++ b/backend/solr/docstorage.py
@@ -16,6 +16,7 @@
 # USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from .doc import SolrDoc
+from .keywordmodel import SolrHierarchy
 
 import pysolr
 
@@ -41,6 +42,11 @@ except:
 
 
 class SolrDocStorage:
+    """
+    Provides functionality to strore / modify and retrive documents
+    from Solr
+    """
+
     def __init__(self, config: dict):
         # we'll modify the original configuration
         _conf = copy.deepcopy(config)
@@ -118,6 +124,4 @@ class SolrDocStorage:
         return None
 
 
-__all__ = [
-    'SolrDocStorage'
-]
+__all__ = ["SolrDocStorage"]

--- a/backend/solr/keywordmodel.py
+++ b/backend/solr/keywordmodel.py
@@ -69,6 +69,8 @@ class SolrHierarchy:
         return bytes(hierarchy, "utf-8").decode("unicode_escape")
 
 
+
+
 MAX_ROWS = 5000
 
 
@@ -144,7 +146,6 @@ class SolrKeywords(SolrAbstract):
         :param new:
         :return:
         """
-
         self.delete(old)
         self.add(new)
 

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -8,7 +8,7 @@ from flask_jsonpify import jsonify
 # TODO hack to modify the config before the app gets initialized
 # we should use a better fixture where the app gets initialized with our
 # desired configurations
-from backend.solr import config, SolrDoc, SolrHierarchy
+from backend.solr import config, SolrDoc, SolrHierarchy, SolrDocKeyword, SolrDocKeywordTypes
 
 # reinit for test
 config_keyword_model = config.keyword_model_solr
@@ -102,7 +102,8 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
         doc = application.solr.docs.get(id)
-        self.assertEqual(doc.keywords, ["a", "b", "c"])
+        # TODO change this to correct keyword types
+        self.assertEqual(doc.keywords, [SolrDocKeyword(kw, SolrDocKeywordTypes.KWM) for kw in ["a", "b", "c"]])
 
 
     def test_documents(self):

--- a/tests/test_docstorage.py
+++ b/tests/test_docstorage.py
@@ -1,4 +1,4 @@
-from backend.solr import SolrDocStorage, SolrDoc
+from backend.solr import SolrDocStorage, SolrDoc, SolrDocKeyword, SolrDocKeywordTypes
 
 import unittest
 from pathlib import Path
@@ -56,27 +56,34 @@ class DocStorageTestCase(unittest.TestCase):
         self.assertFalse(doc.keywords)
 
     def test_initial_keywords(self):
-        doc = SolrDoc(self.doc_paths[0], "key1", "key2")
+        kw1 = SolrDocKeyword("key1", SolrDocKeywordTypes.KWM)
+        kw2 = SolrDocKeyword("key2", SolrDocKeywordTypes.KWM)
+
+        doc = SolrDoc(self.doc_paths[0], kw1, kw2)
         SOLR_DOCS.add(doc)
 
         doc = SOLR_DOCS.get(doc.path)
 
-        self.assertTrue("key1" in doc.keywords)
-        self.assertTrue("key2" in doc.keywords)
+        self.assertTrue(kw1 in doc.keywords)
+        self.assertTrue(kw2 in doc.keywords)
 
     def test_update_keywords(self):
-        doc = SolrDoc(self.doc_paths[0], "key1", "key2")
+        kw1 = SolrDocKeyword("key1", SolrDocKeywordTypes.KWM)
+        kw2 = SolrDocKeyword("key2", SolrDocKeywordTypes.KWM)
+        kw3 = SolrDocKeyword("key3", SolrDocKeywordTypes.KWM)
+
+        doc = SolrDoc(self.doc_paths[0], kw1, kw2)
         SOLR_DOCS.add(doc)
 
         doc = SOLR_DOCS.get(doc.path)
-        doc.keywords.remove("key1")
-        doc.keywords.append("key3")
+        doc.keywords.remove(kw1)
+        doc.keywords.append(kw3)
         SOLR_DOCS.update(doc)
 
         doc = SOLR_DOCS.get(doc.path)
-        self.assertTrue("key1" not in doc.keywords)
-        self.assertTrue("key2" in doc.keywords)
-        self.assertTrue("key3" in doc.keywords)
+        self.assertTrue(kw1 not in doc.keywords)
+        self.assertTrue(kw2 in doc.keywords)
+        self.assertTrue(kw3 in doc.keywords)
 
 
 SOLR_DOCS = SolrDocStorage(DocStorageTestCase.config)


### PR DESCRIPTION
- add functionality to apply the keyword model on docs
- apply works docswise (for later @markuswich  proposes to store all the keywords in each hierarchy with corresponding parents to get rid of the recursive call, this would also allow to use Solr's seach and would allow to search multiple documents at once)
- @markuswich   see `TODOS` in `test_controller.py` and in `app.py` 
- some more comments and type hints added