### PR TITLE
Feature/multilanguage search support

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -17,3 +17,6 @@ tar xzf solr-8.5.1.tgz
 rm solr-8.5.1.tgz
 
 popd
+
+# create log dir
+mkdir -p backend/log/tika

--- a/app.py
+++ b/app.py
@@ -185,13 +185,15 @@ def get_documents():
         sort_field = request.args.get("sort_field", "id")
         sort_order = request.args.get("sort_order", "asc")
         search_term = request.args.get("search_term", "")
+        keywords_only = request.args.get("keywords_only", False)
 
         total_pages, docs = solr.docs.page(
             page,
             num_per_page,
             sort_field,
             sort_order,
-            search_term
+            search_term,
+            keywords_only
         )
 
         docs = [doc.as_dict() for doc in docs]
@@ -207,6 +209,7 @@ def get_documents():
 
         return res, 200
     except Exception as e:
+        log.error(f"/documents {e}")
         return jsonify(f"Bad Gateway to solr: {e}"), 502
 
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+from .translator import Translator

--- a/backend/solr/config.py
+++ b/backend/solr/config.py
@@ -14,7 +14,6 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 # USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 keyword_model_solr = {
     "corename": "keyword_model",
     "url": "http://18.235.6.254:8983/solr",
@@ -41,6 +40,11 @@ doc_storage_solr = {
     "url": "http://18.235.6.254:8983/solr",
     # "url": "http://localhost:8983/solr",
     "always_commit": True,  # will instantly apply changes, maybe change later
+    # the translator uses the google translation api to detect and translate
+    # the search terms. If you don't want that your search terms are translated
+    # by google set the target lang array to be empty. See "googletrans" package
+    # for more information on language codes.
+    "translator_target_languages": ["de", "en"]
 }
 
 keyword_statistics_solr = {

--- a/backend/solr/doc.py
+++ b/backend/solr/doc.py
@@ -153,7 +153,7 @@ class SolrDoc:
             file_type=hit["type"],
             lang=hit["language"],
             size=hit["size"],
-            creation_date=hit["creation_date"],
+            creation_date=hit["creation_date"] if "creation_date" in hit else "unknown",
             last_modified=hit["last_modified"],
             content=hit["content"],
         )

--- a/backend/solr/docstorage.py
+++ b/backend/solr/docstorage.py
@@ -30,6 +30,7 @@ from urlpath import URL
 import copy
 import json
 import datetime
+from googletrans import Translator
 
 
 # TODO setup a logging class discuss with everyone before
@@ -72,6 +73,7 @@ class SolrDocStorage:
         _conf["url"] = str(self.url)
         # connection to the solr instance
         self.con = pysolr.Solr(**_conf)
+        self.translator = Translator()
 
     def add(self, *docs: SolrDoc) -> bool:
         """
@@ -148,6 +150,13 @@ class SolrDocStorage:
         search_query = "*:*"
         if search_term:
             search_terms = search_term.split()
+
+            eng_search_terms = self.translator.translate(search_terms, src="de", dest="en")
+            ger_search_terms = self.translator.translate(search_terms, src="en", dest="de")
+
+            search_terms = {term.text for term in eng_search_terms}
+            search_terms.update(term.text for term in ger_search_terms)
+
             search_query = " OR ".join(
                 f"{field}:*{search_term}*"
                 for field in search_fields

--- a/backend/translator.py
+++ b/backend/translator.py
@@ -1,0 +1,26 @@
+from googletrans import Translator as GoogleTrans
+from typing import List, Set
+
+
+class Translator:
+    def __init__(self, target_languages: List[str]):
+        self.target_languages = target_languages
+        self.translator = GoogleTrans()
+
+    def translate(self, words: List[str]) -> Set[str]:
+        """
+        Translates a list of words into the target languages with which the Translator
+        was initialized.
+
+        :param words: List of words to translate in the target languages
+        :return: Translation results without context to which language they belong
+        """
+        res = set(words)
+        for lang in self.target_languages:
+            translated = self.translator.translate(words, src="auto", dest=lang)
+            res.update(word.text for word in translated)
+
+        return res
+
+
+__all__ = ["Translator"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pysolr
 # file processing
 tika
 langdetect
+googletrans
 # machine learning / data science
 nltk
 sklearn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def solr_docs(request, solr_docs_core):
         "corename": "test_documents_core",
         "url": "http://localhost:8983/solr/",
         "always_commit": True,
+        "translator_target_languages": ["de", "en"]
     }
 
     request.cls.solr_docs = SolrDocStorage(config)

--- a/tests/test_docstorage.py
+++ b/tests/test_docstorage.py
@@ -3,173 +3,233 @@ import unittest
 from backend.solr import SolrDocStorage, SolrDoc, SolrDocKeyword, SolrDocKeywordTypes
 
 
+@pytest.fixture
+def doc_with_keyword_in_content(solr_docs):
+    doc_id = "doc_with_kw_in_content"
+    doc = SolrDoc(
+        doc_id,
+        content="keyword",
+        title="title",
+        file_type="file_type",
+        lang="lang",
+        size=1,
+    )
+    solr_docs.update(doc)
+    return doc_id
+
+
+@pytest.fixture
+def doc_with_keyword_in_keywords_field(solr_docs):
+    doc_id = "doc_with_kw_in_kws"
+    doc = SolrDoc(
+        doc_id,
+        SolrDocKeyword("keyword", SolrDocKeywordTypes.MANUAL),
+        content="content",
+        title="title",
+        file_type="file_type",
+        lang="lang",
+        size=1,
+    )
+    solr_docs.update(doc)
+    return doc_id
+
+
+@pytest.fixture
+def doc_paths():
+    import os
+
+    base = f"{os.getcwd()}/tests/test_docstorage_files/test"
+    doc_types = ["pdf", "txt", "pptx", "docx"]
+
+    doc_paths = [f"{base}.{doc_type}" for doc_type in doc_types]
+    return doc_paths
+
+
+@pytest.fixture
+def docs_in_solr(solr_docs, doc_paths):
+    docs = [SolrDoc(path) for path in doc_paths]
+    solr_docs.add(*docs)
+    return docs
+
+
+@pytest.fixture
+def doc(docs_in_solr):
+    return docs_in_solr[0]
+
+
+@pytest.fixture
+def kw1():
+    return SolrDocKeyword("key1", SolrDocKeywordTypes.KWM)
+
+
+@pytest.fixture
+def kw2():
+    return SolrDocKeyword("key2", SolrDocKeywordTypes.KWM)
+
+
+@pytest.fixture
+def kw3():
+    return SolrDocKeyword("key3", SolrDocKeywordTypes.KWM)
+
+
+@pytest.fixture
+def doc_with_initial_keywords(solr_docs, doc_paths, kw1, kw2):
+    doc = SolrDoc(doc_paths[0], kw1, kw2)
+    solr_docs.add(doc)
+    return doc
+
+
+@pytest.fixture
+def doc_where_tika_cant_find_language(docs_in_solr):
+    return docs_in_solr[3]
+
+
+@pytest.fixture
+def doc_with_key1(solr_docs, doc_paths, kw1):
+    doc = SolrDoc(doc_paths[0], kw1)
+    solr_docs.add(doc)
+    return doc
+
+
+@pytest.fixture
+def doc_with_key2(solr_docs, doc_paths, kw2):
+    doc = SolrDoc(doc_paths[1], kw2)
+    solr_docs.add(doc)
+    return doc
+
+
 @pytest.mark.usefixtures("solr_docs")
-class TestDocStorage(unittest.TestCase):
-    def setUp(self):
-        import os
-
-        base = f"{os.getcwd()}/tests/test_docstorage_files/test"
-        self.doc_types = ["pdf", "txt", "pptx", "docx"]
-
-        self.doc_paths = [f"{base}.{doc_type}" for doc_type in self.doc_types]
-        self.docs = [SolrDoc(path) for path in self.doc_paths]
-
-    def test_add_and_search(self):
-        self.solr_docs.add(*self.docs)
-
+class TestDocStorage:
+    def test_add_and_search(self, docs_in_solr):
         added = self.solr_docs.search("*:*")
-        self.assertEqual(len(added), len(self.docs))
+        assert len(added) == len(docs_in_solr)
 
-    def test_delete(self):
-        self.solr_docs.add(*self.docs)
-
-        deleted = self.docs[0]
+    def test_delete(self, docs_in_solr):
+        deleted = docs_in_solr[0]
 
         self.solr_docs.delete(deleted.path)
-        self.assertTrue(deleted.path not in self.solr_docs)
+        assert deleted.path not in self.solr_docs
 
-    def test_contains(self):
-        self.solr_docs.add(*self.docs)
-
-        for doc in self.docs:
-            self.assertTrue(doc.path in self.solr_docs)
+    def test_contains(self, docs_in_solr):
+        for doc in docs_in_solr:
+            assert doc.path in self.solr_docs
 
         not_existing = "/this/file/does/not/exist"
-        self.assertTrue(not_existing not in self.solr_docs)
+        assert not_existing not in self.solr_docs
 
-    def test_empty_keywords(self):
-        doc = SolrDoc(self.doc_paths[0])
-        self.solr_docs.add(doc)
-        doc = self.solr_docs.get(doc.path)
+    def test_empty_keywords(self, docs_in_solr):
+        docs = self.solr_docs.get(*[doc.path for doc in docs_in_solr])
+        for doc in docs:
+            assert not doc.keywords
 
-        self.assertFalse(doc.keywords)
+    def test_initial_keywords(self, doc_with_initial_keywords, kw1, kw2):
+        doc = self.solr_docs.get(doc_with_initial_keywords.path)
 
-    def test_initial_keywords(self):
-        kw1 = SolrDocKeyword("key1", SolrDocKeywordTypes.KWM)
-        kw2 = SolrDocKeyword("key2", SolrDocKeywordTypes.KWM)
+        assert kw1 in doc.keywords
+        assert kw2 in doc.keywords
 
-        doc = SolrDoc(self.doc_paths[0], kw1, kw2)
-        self.solr_docs.add(doc)
-
-        doc = self.solr_docs.get(doc.path)
-
-        self.assertTrue(kw1 in doc.keywords)
-        self.assertTrue(kw2 in doc.keywords)
-
-    def test_update_keywords(self):
-        kw1 = SolrDocKeyword("key1", SolrDocKeywordTypes.KWM)
-        kw2 = SolrDocKeyword("key2", SolrDocKeywordTypes.KWM)
-        kw3 = SolrDocKeyword("key3", SolrDocKeywordTypes.KWM)
-
-        doc = SolrDoc(self.doc_paths[0], kw1, kw2)
-        self.solr_docs.add(doc)
-
-        doc = self.solr_docs.get(doc.path)
+    def test_update_keywords(self, doc_with_initial_keywords, kw1, kw2, kw3):
+        doc = self.solr_docs.get(doc_with_initial_keywords.path)
         doc.keywords.remove(kw1)
         doc.keywords.add(kw3)
         self.solr_docs.update(doc)
 
         doc = self.solr_docs.get(doc.path)
-        self.assertTrue(kw1 not in doc.keywords)
-        self.assertTrue(kw2 in doc.keywords)
-        self.assertTrue(kw3 in doc.keywords)
+        assert kw1 not in doc.keywords
+        assert kw2 in doc.keywords
+        assert kw3 in doc.keywords
 
-    def test_correct_language_extraction(self):
-        expected_lang = "en"
+    def test_correct_language_extraction(self, doc_where_tika_cant_find_language):
+        doc = self.solr_docs.get(doc_where_tika_cant_find_language.path)
+        assert doc.lang == "en"
 
-        # doc where tika can't parse the language
-        doc = self.docs[3]
-        self.solr_docs.add(doc)
-
-        doc = self.solr_docs.get(doc.path)
-
-        self.assertEqual(doc.lang, expected_lang)
-
-    def test_pagination_sort_asc(self):
-        self.solr_docs.add(*self.docs)
-
+    def test_pagination_sort_asc(self, docs_in_solr):
         expected_page1 = ["test.docx", "test.pdf"]
         _, docs = self.solr_docs.page(0, 2, "id", "asc")
         doc_ids = [doc.id for doc in docs]
-        self.assertEqual(doc_ids, expected_page1)
+        assert doc_ids == expected_page1
 
         expected_page2 = ["test.pptx", "test.txt"]
         _, docs = self.solr_docs.page(1, 2, "id", "asc")
         doc_ids = [doc.id for doc in docs]
-        self.assertEqual(doc_ids, expected_page2)
+        assert doc_ids == expected_page2
 
-    def test_pagination_sort_desc(self):
-        self.solr_docs.add(*self.docs)
-
+    def test_pagination_sort_desc(self, docs_in_solr):
         expected_page1 = ["test.txt", "test.pptx"]
         _, docs = self.solr_docs.page(0, 2, "id", "desc")
         doc_ids = [doc.id for doc in docs]
-        self.assertEqual(doc_ids, expected_page1)
+        assert doc_ids == expected_page1
 
         expected_page2 = ["test.pdf", "test.docx"]
         _, docs = self.solr_docs.page(1, 2, "id", "desc")
         doc_ids = [doc.id for doc in docs]
-        self.assertEqual(doc_ids, expected_page2)
+        assert doc_ids == expected_page2
 
-    def test_total_num_pages(self):
-        self.solr_docs.add(*self.docs)
-
+    def test_total_num_pages(self, docs_in_solr):
         total_num_pages, _ = self.solr_docs.page(0, 1)
-        self.assertEqual(total_num_pages, 4)
+        assert total_num_pages == 4
 
         total_num_pages, _ = self.solr_docs.page(0, 2)
-        self.assertEqual(total_num_pages, 2)
+        assert total_num_pages == 2
 
         total_num_pages, _ = self.solr_docs.page(0, 3)
-        self.assertEqual(total_num_pages, 2)
+        assert total_num_pages == 2
 
         total_num_pages, _ = self.solr_docs.page(0, 4)
-        self.assertEqual(total_num_pages, 1)
+        assert total_num_pages == 1
 
     def test_pagination_sort_field_does_not_exist(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.solr_docs.page(0, 1, "not_existing_field", "asc")
 
-    def test_pagination_search_term(self):
-        self.solr_docs.add(*self.docs)
-
+    def test_pagination_search_term(self, docs_in_solr):
         try:
             self.solr_docs.page(search_term="asdf")
         except Exception as e:
             self.fail(f"Raised unexpected exception: {e}")
 
-    def test_pagination_year_search(self):
+    def test_pagination_year_search(self, docs_in_solr):
         import datetime
-
-        self.solr_docs.add(*self.docs)
 
         current_year = datetime.datetime.now().strftime("%Y")
         _, docs = self.solr_docs.page(search_term=current_year)
 
-        self.assertEqual(len(docs), 4)
+        assert len(docs) == 4
 
-    def test_pagination_size_search(self):
-        self.solr_docs.add(*self.docs)
-
+    def test_pagination_size_search(self, docs_in_solr):
         _, docs = self.solr_docs.page(search_term="8137")
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
-    def test_doc_last_modified_date_changes_on_each_update(self):
+    def test_pagination_keywords_only_search(
+        self, doc_with_keyword_in_content, doc_with_keyword_in_keywords_field
+    ):
+        _, docs = self.solr_docs.page(search_term="keyword", keywords_only=True)
+        assert len(docs) == 1
+
+    def test_pagination_not_keywords_only_search(
+        self, doc_with_keyword_in_content, doc_with_keyword_in_keywords_field
+    ):
+        _, docs = self.solr_docs.page(search_term="keyword", keywords_only=False)
+        assert len(docs) == 2
+
+    def test_pagination_search_term_consists_of_multiple_words(
+        self, doc_with_key1, doc_with_key2
+    ):
+        _, docs = self.solr_docs.page(search_term="key1 key2")
+        assert len(docs) == 2
+
+    def test_doc_last_modified_date_changes_on_each_update(self, doc):
         import time
         import copy
 
-        doc = self.docs[0]
-
-        self.solr_docs.add(doc)
-        doc_before = self.solr_docs.get(doc.id)
-
         # wait and update to check the the modified date has changed
         time.sleep(5)
-        self.solr_docs.update(copy.deepcopy(doc_before))
+        self.solr_docs.update(copy.deepcopy(doc))
         doc_after = self.solr_docs.get(doc.id)
 
-        self.assertNotEqual(doc_before.last_modified, doc_after.last_modified)
-        self.assertEqual(doc_before.creation_date, doc_after.creation_date)
+        assert doc.last_modified != doc_after.last_modified
+        assert doc.creation_date == doc_after.creation_date
+
 
     def test_uploading_empty_documents(self):
         doc = SolrDoc("tests/test_docstorage_files/empty_doc.txt")

--- a/tests/test_docstorage.py
+++ b/tests/test_docstorage.py
@@ -97,6 +97,33 @@ def doc_with_key2(solr_docs, doc_paths, kw2):
     solr_docs.add(doc)
     return doc
 
+@pytest.fixture
+def doc_with_germany(solr_docs):
+    doc_id = "doc_with_germany"
+    doc = SolrDoc(
+        doc_id,
+        content="germany",
+        title="title",
+        file_type="file_type",
+        lang="lang",
+        size=1,
+    )
+    solr_docs.update(doc)
+    return doc_id
+
+@pytest.fixture
+def doc_with_deutschland(solr_docs):
+    doc_id = "doc_with_deutschland"
+    doc = SolrDoc(
+        doc_id,
+        content="deutschland",
+        title="title",
+        file_type="file_type",
+        lang="lang",
+        size=1,
+    )
+    solr_docs.update(doc)
+    return doc_id
 
 @pytest.mark.usefixtures("solr_docs")
 class TestDocStorage:
@@ -229,6 +256,13 @@ class TestDocStorage:
 
         assert doc.last_modified != doc_after.last_modified
         assert doc.creation_date == doc_after.creation_date
+
+    def test_translation_search(self, doc_with_germany, doc_with_deutschland):
+        _, docs = self.solr_docs.page(search_term="germany")
+        assert len(docs) == 2
+
+        _, docs = self.solr_docs.page(search_term="deutschland")
+        assert len(docs) == 2
 
 
     def test_uploading_empty_documents(self):

--- a/utils/data_preprocessing.py
+++ b/utils/data_preprocessing.py
@@ -33,7 +33,7 @@ import threading as th
 
 # TODO tika should be configure correctly to ignore images and other unnecessary data
 os.environ["TIKA_PATH"] = "./downloads/tika"
-print(f"Tika server set to: {os.environ['TIKA_PATH']}")
+os.environ["TIKA_LOG_PATH"] = "./backend/log/tika"
 
 from tika import parser, detector, language
 from typing import Set, List, Tuple


### PR DESCRIPTION
- each word in the `search_term` from the frontend gets translated into `target_languages` (see config)
- results will be returned as an or query
- added `TIKA_LOG_PATH` to further investigate the tika errors
